### PR TITLE
Release v0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ## Features
 - Only the latest Vue syntax (including [Reactivity Transform](https://vuejs.org/guide/extras/reactivity-transform.html))
+- Over **190** snippets 
 - TypeScript-first
 - Nuxt 3, Pinia, VueUse & Vue Router support
 - Strategically placed tabstops
@@ -352,7 +353,7 @@ $0
 </tr>
 
 <tr>
-<td><code>vkeepAlive</code></td>
+<td><code>vKeepAlive</code></td>
 <td>Vue KeepAlive</td>
 <td>
 
@@ -366,7 +367,7 @@ $0
 </tr>
 
 <tr>
-<td><code>vteleport</code></td>
+<td><code>vTeleport</code></td>
 <td>Vue teleport</td>
 <td>
 
@@ -790,6 +791,90 @@ v-if="\$slots.${1:label} || ${2:$1}"
 <${1|template,...|} v-if="$2">
   $0
 </$1>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vTransition</code></td>
+<td>Vue Transition</td>
+<td>
+
+```html
+<Transition $1>
+  $0
+</Transition>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vTransition:name</code> / <code>nTransition</code></td>
+<td>Vue Transition with name</td>
+<td>
+
+```html
+<Transition name="$1" $2>
+  $0
+</Transition>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vTransition:type</code></td>
+<td>Vue Transition with type</td>
+<td>
+
+```html
+<Transition type="${1|transition,...|}" $2>
+  $0
+</Transition>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vTransition:appear</code></td>
+<td>Vue Transition with appear</td>
+<td>
+
+```html
+<Transition appear $1>
+  $0
+</Transition>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vTransitionGroup</code></td>
+<td>Vue TransitionGroup</td>
+<td>
+
+```html
+<TransitionGroup name="$1" as="${2|ul,...|}" $3>
+  $0
+</TransitionGroup>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vSuspense</code></td>
+<td>Vue Suspense</td>
+<td>
+
+```html
+<Suspense>
+  $0
+</Suspense>
 ```
 
 </td>
@@ -1470,7 +1555,7 @@ const ${1:name} = \$ref<$2>($3)
 </tr>
 
 <tr>
-<td><code>vcomputed$</code> / <code>vcrt</code></td>
+<td><code>vcomputed$</code> / <code>vct</code></td>
 <td>Vue $computed</td>
 <td>
 
@@ -1536,7 +1621,7 @@ const ${1:name} = \$shallowRef($2)
 
 <tr>
 <td><code>v$</code></td>
-<td>Vue $() </td>
+<td>Vue $() destructuring</td>
 <td>
 
 ```javascript
@@ -1548,11 +1633,11 @@ $($1)
 
 <tr>
 <td><code>v$</code></td>
-<td>Vue $()</td>
+<td>Vue $$() escape hint</td>
 <td>
 
 ```javascript
-$($1)
+$$($1)
 ```
 
 </td>

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
 
 ## Features
 - Only the latest Vue syntax (including [Reactivity Transform](https://vuejs.org/guide/extras/reactivity-transform.html))
-- Over **190** snippets 
+- Over **200** snippets 
 - TypeScript-first
 - Nuxt 3, Pinia, VueUse & Vue Router support
 - Strategically placed tabstops
 - Prefixes created with exact-match in mind 
-- GitHub Copilot compliant
+- (Mostly) GitHub Copilot compliant
 - Auto-generated documentation
 
 ## Setup
@@ -313,6 +313,18 @@ $0
 </tr>
 
 <tr>
+<td><code>component</code></td>
+<td>component</td>
+<td>
+
+```html
+<component>$0</component>
+```
+
+</td>
+</tr>
+
+<tr>
 <td><code>nslot</code></td>
 <td>named slot</td>
 <td>
@@ -381,6 +393,107 @@ $0
 </tr>
 
 <tr>
+<td><code>vTransition</code></td>
+<td>Vue Transition</td>
+<td>
+
+```html
+<Transition $1>
+  $0
+</Transition>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vTransition:name</code> / <code>nTransition</code></td>
+<td>Vue Transition with name</td>
+<td>
+
+```html
+<Transition name="$1" $2>
+  $0
+</Transition>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vTransition:type</code></td>
+<td>Vue Transition with type</td>
+<td>
+
+```html
+<Transition type="${1|transition,...|}" $2>
+  $0
+</Transition>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vTransition:appear</code></td>
+<td>Vue Transition with appear</td>
+<td>
+
+```html
+<Transition appear $1>
+  $0
+</Transition>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vTransitionGroup</code></td>
+<td>Vue TransitionGroup</td>
+<td>
+
+```html
+<TransitionGroup name="$1" as="${2|ul,...|}" $3>
+  $0
+</TransitionGroup>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vSuspense</code></td>
+<td>Vue Suspense</td>
+<td>
+
+```html
+<Suspense>
+  $0
+</Suspense>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vSuspense:fallback</code></td>
+<td>Vue Suspense with fallback</td>
+<td>
+
+```html
+<Suspense>
+  $0
+  <template #fallback>
+    $1
+  </template>
+</Suspense>
+```
+
+</td>
+</tr>
+
+<tr>
 <td><code>vtext</code></td>
 <td>v-text</td>
 <td>
@@ -417,7 +530,7 @@ v-show="$1"
 </tr>
 
 <tr>
-<td><code>vif</code></td>
+<td><code>vif</code> / <code>if</code></td>
 <td>v-if</td>
 <td>
 
@@ -429,7 +542,7 @@ v-if="$1"
 </tr>
 
 <tr>
-<td><code>velse</code></td>
+<td><code>velse</code> / <code>else</code></td>
 <td>v-else</td>
 <td>
 
@@ -441,7 +554,7 @@ v-else
 </tr>
 
 <tr>
-<td><code>velif</code></td>
+<td><code>velif</code> / <code>elif</code></td>
 <td>v-else-if</td>
 <td>
 
@@ -645,24 +758,12 @@ ref="$1"
 </tr>
 
 <tr>
-<td><code>vto</code></td>
-<td>router link :to prop</td>
-<td>
-
-```html
-${1|to,...|}="$2"
-```
-
-</td>
-</tr>
-
-<tr>
 <td><code>vname</code></td>
 <td>name property</td>
 <td>
 
 ```html
-name="$1"
+${1|name,...|}="$1"
 ```
 
 </td>
@@ -693,8 +794,68 @@ ${1|is,...|}="$2"
 </tr>
 
 <tr>
-<td><code>von-emit</code></td>
-<td>emit event</td>
+<td><code>vclass</code> / <code>vc</code></td>
+<td>Vue classes</td>
+<td>
+
+```html
+:class="[$1]"
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vclass:cond</code> / <code>vcc</code></td>
+<td>Vue conditional classes</td>
+<td>
+
+```html
+:class="{ $1: $2 }"
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vstyle</code></td>
+<td>Vue inline style</td>
+<td>
+
+```html
+:style="{ $1: $2 }"
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vstyle:list</code></td>
+<td>Vue inline style list</td>
+<td>
+
+```html
+:style="[$1]"
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vti</code></td>
+<td>Vue text interpolation</td>
+<td>
+
+```html
+{{ $1 }}
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vemit</code></td>
+<td>Vue emit event</td>
 <td>
 
 ```html
@@ -723,18 +884,6 @@ v-if="\$slots.${1:default}"
 
 ```html
 v-if="\$slots.${1:label} || ${2:$1}"
-```
-
-</td>
-</tr>
-
-<tr>
-<td><code>vti</code></td>
-<td>Vue text interpolation</td>
-<td>
-
-```html
-{{ $1 }}
 ```
 
 </td>
@@ -791,90 +940,6 @@ v-if="\$slots.${1:label} || ${2:$1}"
 <${1|template,...|} v-if="$2">
   $0
 </$1>
-```
-
-</td>
-</tr>
-
-<tr>
-<td><code>vTransition</code></td>
-<td>Vue Transition</td>
-<td>
-
-```html
-<Transition $1>
-  $0
-</Transition>
-```
-
-</td>
-</tr>
-
-<tr>
-<td><code>vTransition:name</code> / <code>nTransition</code></td>
-<td>Vue Transition with name</td>
-<td>
-
-```html
-<Transition name="$1" $2>
-  $0
-</Transition>
-```
-
-</td>
-</tr>
-
-<tr>
-<td><code>vTransition:type</code></td>
-<td>Vue Transition with type</td>
-<td>
-
-```html
-<Transition type="${1|transition,...|}" $2>
-  $0
-</Transition>
-```
-
-</td>
-</tr>
-
-<tr>
-<td><code>vTransition:appear</code></td>
-<td>Vue Transition with appear</td>
-<td>
-
-```html
-<Transition appear $1>
-  $0
-</Transition>
-```
-
-</td>
-</tr>
-
-<tr>
-<td><code>vTransitionGroup</code></td>
-<td>Vue TransitionGroup</td>
-<td>
-
-```html
-<TransitionGroup name="$1" as="${2|ul,...|}" $3>
-  $0
-</TransitionGroup>
-```
-
-</td>
-</tr>
-
-<tr>
-<td><code>vSuspense</code></td>
-<td>Vue Suspense</td>
-<td>
-
-```html
-<Suspense>
-  $0
-</Suspense>
 ```
 
 </td>
@@ -1735,6 +1800,140 @@ const hasSlot = (name: string) => !!slots[name]
 </table>
 
 
+### Vue Router template
+
+<table width="100%">
+
+<tr>
+<td>Prefix</td>
+<td>Name</td>
+<td>Body</td>
+</tr>
+
+<tr>
+<td><code>vto</code></td>
+<td>Vue Router to</td>
+<td>
+
+```html
+${1|to,...|}="$2"
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vto:param</code></td>
+<td>Vue Router :to with param</td>
+<td>
+
+```html
+:to="`$1${${2:id}}$3`"
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vto:obj</code></td>
+<td>Vue Router :to object</td>
+<td>
+
+```html
+:to="{ $1 }"
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vto:name</code></td>
+<td>Vue Router :to name</td>
+<td>
+
+```html
+:to="{ name: '$1',$2 }"
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vto:path</code></td>
+<td>Vue Router :to path</td>
+<td>
+
+```html
+:to="{ path: '$1',$2 }"
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vview</code></td>
+<td>RouterView</td>
+<td>
+
+```html
+<RouterView>
+  $0
+</RouterView>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vlink</code></td>
+<td>RouterLink</td>
+<td>
+
+```html
+<RouterLink to="$1">$3</RouterLink>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vlink:obj</code></td>
+<td>RouterLink with object</td>
+<td>
+
+```html
+<RouterLink :to="{ $1 }">$3</RouterLink>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vlink:name</code></td>
+<td>RouterLink with name</td>
+<td>
+
+```html
+<RouterLink :to="{ name: '$1'$2 }">$4</RouterLink>
+```
+
+</td>
+</tr>
+
+<tr>
+<td><code>vlink:path</code></td>
+<td>RouterLink with path</td>
+<td>
+
+```html
+<RouterLink :to="{ path: '$1'$2 }">$4</RouterLink>
+```
+
+</td>
+</tr>
+</table>
+
+
 ### Pinia
 
 <table width="100%">
@@ -2329,7 +2528,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtLink</td>
 <td>
 
-```javascript
+```html
 <NuxtLink to="$1">$3</NuxtLink>
 ```
 
@@ -2341,7 +2540,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtLink with target _blank</td>
 <td>
 
-```javascript
+```html
 <NuxtLink to="$1" target="_blank">$3</NuxtLink>
 ```
 
@@ -2353,7 +2552,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtLink with param</td>
 <td>
 
-```javascript
+```html
 <NuxtLink :to="`$1${${2:id}}$3`">$5</NuxtLink>
 ```
 
@@ -2365,7 +2564,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtLink with object</td>
 <td>
 
-```javascript
+```html
 <NuxtLink :to="{ $1 }">$3</NuxtLink>
 ```
 
@@ -2377,7 +2576,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtLink with name</td>
 <td>
 
-```javascript
+```html
 <NuxtLink :to="{ name: '$1'$2 }">$4</NuxtLink>
 ```
 
@@ -2389,7 +2588,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtLink with path</td>
 <td>
 
-```javascript
+```html
 <NuxtLink :to="{ path: '$1'$2 }">$4</NuxtLink>
 ```
 
@@ -2401,7 +2600,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtLoadingIndicator</td>
 <td>
 
-```javascript
+```html
 <NuxtLoadingIndicator $1/>
 ```
 
@@ -2413,7 +2612,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtLayout</td>
 <td>
 
-```javascript
+```html
 <NuxtLayout $1>$2</NuxtLayout>
 ```
 
@@ -2425,7 +2624,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtLayout with name</td>
 <td>
 
-```javascript
+```html
 <NuxtLayout ${2|name,...|}="$3">$4</NuxtLayout>
 ```
 
@@ -2437,7 +2636,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtPage</td>
 <td>
 
-```javascript
+```html
 <NuxtPage $1/>
 ```
 
@@ -2449,7 +2648,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>NuxtPage with static key</td>
 <td>
 
-```javascript
+```html
 <NuxtPage page-key="static" $1/>
 ```
 
@@ -2461,7 +2660,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>ClientOnly</td>
 <td>
 
-```javascript
+```html
 <ClientOnly $1>$2</ClientOnly>
 ```
 
@@ -2473,7 +2672,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>ClientOnly with fallback props</td>
 <td>
 
-```javascript
+```html
 <ClientOnly fallback-tag="${1:span}" fallback="${2:Loading...}">$3</ClientOnly>
 ```
 
@@ -2485,7 +2684,7 @@ setCookie(event, '${1:cookie}', ${2:value})
 <td>ClientOnly with fallback template</td>
 <td>
 
-```javascript
+```html
 <ClientOnly>
   <template #fallback>
     $0
@@ -2497,11 +2696,11 @@ setCookie(event, '${1:cookie}', ${2:value})
 </tr>
 
 <tr>
-<td><code>nteleport</code></td>
+<td><code>nTeleport</code></td>
 <td>Nuxt Teleport</td>
 <td>
 
-```javascript
+```html
 <Teleport to="$1">
   $0
 </Teleport>

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # Vue Ecosystem Snippets
 
-> Snippets for the modern Vue ecosystem - including Nuxt 3, Pinia, VueUse & VueRouter.
-
-<br>
-
-    🚧 Work in progress 🚧
-
-<br>
-
+> Snippets for the modern Vue ecosystem - including Nuxt 3, Pinia, VueUse & Vue Router.
 
 ![Vue](https://img.shields.io/badge/vue-%2335495e.svg?style=for-the-badge&logo=vuedotjs&logoColor=%234FC08D)
 ![Nuxt](https://img.shields.io/badge/Nuxt-002E3B?style=for-the-badge&logo=nuxtdotjs&logoColor=#00DC82)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-nuxt-snippets",
   "displayName": "Vue Ecosystem Snippets",
-  "description": "Snippets for the modern Vue ecosystem - including Nuxt 3, Pinia, VueUse & VueRouter.",
+  "description": "Snippets for the modern Vue ecosystem - including Nuxt 3, Pinia, VueUse & Vue Router.",
   "version": "0.5.1",
   "license": "MIT",
   "icon": "assets/icon.png",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vue-nuxt-snippets",
   "displayName": "Vue Ecosystem Snippets",
   "description": "Snippets for the modern Vue ecosystem - including Nuxt 3, Pinia, VueUse & Vue Router.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "icon": "assets/icon.png",
   "author": {

--- a/package.json
+++ b/package.json
@@ -126,6 +126,10 @@
       {
         "language": "html",
         "path": "./dist/nuxt-template.code-snippets"
+      },
+      {
+        "language": "html",
+        "path": "./dist/vue-router-template.code-snippets"
       }
     ]
   }

--- a/src/snippets/app.ts
+++ b/src/snippets/app.ts
@@ -1,11 +1,13 @@
 import { XSnippetVariant } from "../models/app.ts";
-import { vue } from "./vue/app.ts";
-import { pinia } from "./pinia/app.ts";
 import { nuxt } from "./nuxt/app.ts";
+import { pinia } from "./pinia/app.ts";
+import { vueRouter } from "./vue-router/app.ts";
+import { vue } from "./vue/app.ts";
 import { vueUse } from "./vueuse/app.ts";
 
 export const variants: XSnippetVariant[] = [
   ...vue,
+  ...vueRouter,
   ...pinia,
   ...nuxt,
   ...vueUse,

--- a/src/snippets/nuxt/template.ts
+++ b/src/snippets/nuxt/template.ts
@@ -69,7 +69,7 @@ export const template: XSnippetDefinition = {
         "</ClientOnly>",
       ],
     },
-    nteleport: {
+    nTeleport: {
       name: "Nuxt Teleport",
       body: '<Teleport to="$1">\n\t$0\n</Teleport>',
     },

--- a/src/snippets/nuxt/template.ts
+++ b/src/snippets/nuxt/template.ts
@@ -3,6 +3,7 @@ import { XSnippetDefinition } from "../../models/app.ts";
 export const template: XSnippetDefinition = {
   meta: {
     title: "Nuxt template",
+    lang: "html",
   },
   snippets: {
     nlink: {

--- a/src/snippets/vue-router/app.ts
+++ b/src/snippets/vue-router/app.ts
@@ -1,0 +1,10 @@
+import { XSnippetVariant } from "../../models/app.ts";
+import { template } from "./template.ts";
+
+export const vueRouter: XSnippetVariant[] = [
+  {
+    label: "Vue Router",
+    fileName: "vue-router-template",
+    snippetDefinitions: [template],
+  },
+];

--- a/src/snippets/vue-router/template.ts
+++ b/src/snippets/vue-router/template.ts
@@ -1,0 +1,50 @@
+import { XSnippetDefinition } from "../../models/app.ts";
+
+export const template: XSnippetDefinition = {
+  meta: {
+    title: "Vue Router template",
+    lang: "html",
+  },
+  snippets: {
+    vto: {
+      name: "Vue Router to",
+      body: '${1|to,:to|}="$2"',
+    },
+    "vto:param": {
+      name: "Vue Router :to with param",
+      body: ':to="`$1${${2:id}}$3`"',
+    },
+    "vto:obj": {
+      name: "Vue Router :to object",
+      body: ':to="{ $1 }"',
+    },
+    "vto:name": {
+      name: "Vue Router :to name",
+      body: `:to="{ name: '$1',$2 }"`,
+    },
+    "vto:path": {
+      name: "Vue Router :to path",
+      body: `:to="{ path: '$1',$2 }"`,
+    },
+    vview: {
+      name: "RouterView",
+      body: "<RouterView>\n\t$0\n</RouterView>",
+    },
+    vlink: {
+      name: "RouterLink",
+      body: '<RouterLink to="$1">$3</RouterLink>',
+    },
+    "vlink:obj": {
+      name: "RouterLink with object",
+      body: '<RouterLink :to="{ $1 }">$3</RouterLink>',
+    },
+    "vlink:name": {
+      name: "RouterLink with name",
+      body: `<RouterLink :to="{ name: '$1'$2 }">$4</RouterLink>`,
+    },
+    "vlink:path": {
+      name: "RouterLink with path",
+      body: `<RouterLink :to="{ path: '$1'$2 }">$4</RouterLink>`,
+    },
+  },
+};

--- a/src/snippets/vue/reactivity-transform.ts
+++ b/src/snippets/vue/reactivity-transform.ts
@@ -20,7 +20,7 @@ export const reactivityTransform: XSnippetDefinition = {
     vcomputed$: {
       name: "Vue $computed",
       body: "const ${1:name} = \\$computed(() => $2)",
-      alt: ["vcrt"],
+      alt: ["vct"],
     },
     "vcomputed$:ts": {
       name: "Vue $computed (typed)",
@@ -46,12 +46,12 @@ export const reactivityTransform: XSnippetDefinition = {
       body: "const ${1:name} = \\$shallowRef($2)",
     },
     "v$": {
-      name: "Vue $() ",
+      name: "Vue $() destructuring",
       body: "$($1)",
     },
     "v$$": {
-      name: "Vue $$()",
-      body: "$$($1)",
+      name: "Vue $$$() escape hint",
+      body: "\$$$($1)",
     },
   },
 };

--- a/src/snippets/vue/template.ts
+++ b/src/snippets/vue/template.ts
@@ -4,7 +4,6 @@ import { XSnippetDefinition } from "../../models/app.ts";
 /**
  * - transition classes and events
  * - router link
- * - class bindings
  */
 export const template: XSnippetDefinition = {
   meta: {
@@ -19,6 +18,10 @@ export const template: XSnippetDefinition = {
     template: {
       name: "template",
       body: "<template>$0</template>",
+    },
+    component: {
+      name: "component",
+      body: "<component>$0</component>",
     },
     nslot: {
       name: "named slot",
@@ -50,6 +53,44 @@ export const template: XSnippetDefinition = {
       name: "Vue teleport",
       body: '<Teleport to="$1">\n\t$0\n</Teleport>',
     },
+    vTransition: {
+      name: "Vue Transition",
+      body: "<Transition $1>\n\t$0\n</Transition>",
+    },
+    "vTransition:name": {
+      name: "Vue Transition with name",
+      body: '<Transition name="$1" $2>\n\t$0\n</Transition>',
+      alt: ["nTransition"],
+    },
+    "vTransition:type": {
+      name: "Vue Transition with type",
+      body:
+        '<Transition type="${1|transition,animation|}" $2>\n\t$0\n</Transition>',
+    },
+    "vTransition:appear": {
+      name: "Vue Transition with appear",
+      body: "<Transition appear $1>\n\t$0\n</Transition>",
+    },
+    vTransitionGroup: {
+      name: "Vue TransitionGroup",
+      body:
+        '<TransitionGroup name="$1" as="${2|ul,div,section|}" $3>\n\t$0\n</TransitionGroup>',
+    },
+    vSuspense: {
+      name: "Vue Suspense",
+      body: "<Suspense>\n\t$0\n</Suspense>",
+    },
+    "vSuspense:fallback": {
+      name: "Vue Suspense with fallback",
+      body: [
+        "<Suspense>",
+        "\t$0",
+        "\t<template #fallback>",
+        "\t\t$1",
+        "\t</template>",
+        "</Suspense>",
+      ],
+    },
     vtext: {
       name: "v-text",
       body: 'v-text="$1"',
@@ -65,14 +106,17 @@ export const template: XSnippetDefinition = {
     vif: {
       name: "v-if",
       body: 'v-if="$1"',
+      alt: ["if"],
     },
     velse: {
       name: "v-else",
       body: "v-else",
+      alt: ["else"],
     },
     velif: {
       name: "v-else-if",
       body: 'v-else-if="$1"',
+      alt: ["elif"],
     },
     vfor: {
       name: "v-for",
@@ -138,13 +182,9 @@ export const template: XSnippetDefinition = {
       name: "Vue ref",
       body: 'ref="$1"',
     },
-    vto: {
-      name: "router link :to prop",
-      body: '${1|to,:to|}="$2"',
-    },
     vname: {
       name: "name property",
-      body: 'name="$1"',
+      body: '${1|name,:name|}="$1"',
     },
     vis: {
       name: "is property",
@@ -154,8 +194,30 @@ export const template: XSnippetDefinition = {
       name: "bind property",
       body: ':${1:prop}="$2"',
     },
-    "von-emit": {
-      name: "emit event",
+    vclass: {
+      name: "Vue classes",
+      body: `:class="[$1]"`,
+      alt: ["vc"],
+    },
+    "vclass:cond": {
+      name: "Vue conditional classes",
+      body: `:class="{ $1: $2 }"`,
+      alt: ["vcc"],
+    },
+    vstyle: {
+      name: "Vue inline style",
+      body: `:style="{ $1: $2 }"`,
+    },
+    "vstyle:list": {
+      name: "Vue inline style list",
+      body: `:style="[$1]"`,
+    },
+    vti: {
+      name: "Vue text interpolation",
+      body: "{{ $1 }}",
+    },
+    vemit: {
+      name: "Vue emit event",
       body:
         "@${1|click,input,change,focus,blur|}=\"\\$emit('${2:$1}', \\$event)\"",
     },
@@ -166,10 +228,6 @@ export const template: XSnippetDefinition = {
     "vif:slot-prop": {
       name: "v-if slot or prop defined",
       body: 'v-if="\\$slots.${1:label} || ${2:$1}"',
-    },
-    vti: {
-      name: "Vue text interpolation",
-      body: "{{ $1 }}",
     },
     vform: {
       name: "form submit.prevent",
@@ -202,33 +260,6 @@ export const template: XSnippetDefinition = {
         "\t$0",
         "</$1>",
       ],
-    },
-    vTransition: {
-      name: "Vue Transition",
-      body: "<Transition $1>\n\t$0\n</Transition>",
-    },
-    "vTransition:name": {
-      name: "Vue Transition with name",
-      body: '<Transition name="$1" $2>\n\t$0\n</Transition>',
-      alt: ["nTransition"],
-    },
-    "vTransition:type": {
-      name: "Vue Transition with type",
-      body:
-        '<Transition type="${1|transition,animation|}" $2>\n\t$0\n</Transition>',
-    },
-    "vTransition:appear": {
-      name: "Vue Transition with appear",
-      body: "<Transition appear $1>\n\t$0\n</Transition>",
-    },
-    vTransitionGroup: {
-      name: "Vue TransitionGroup",
-      body:
-        '<TransitionGroup name="$1" as="${2|ul,div,section|}" $3>\n\t$0\n</TransitionGroup>',
-    },
-    vSuspense: {
-      name: "Vue Suspense",
-      body: "<Suspense>\n\t$0\n</Suspense>",
     },
   },
 };

--- a/src/snippets/vue/template.ts
+++ b/src/snippets/vue/template.ts
@@ -2,7 +2,6 @@ import { XSnippetDefinition } from "../../models/app.ts";
 
 // TODO
 /**
- * - transition elements
  * - transition classes and events
  * - router link
  * - class bindings
@@ -41,13 +40,13 @@ export const template: XSnippetDefinition = {
       name: "Vue component",
       body: '<component :is="$1">$0</component>',
     },
-    vkeepAlive: {
+    vKeepAlive: {
       name: "Vue KeepAlive",
       "body": [
         "<KeepAlive $1>\n\t$0\n</KeepAlive>",
       ],
     },
-    vteleport: {
+    vTeleport: {
       name: "Vue teleport",
       body: '<Teleport to="$1">\n\t$0\n</Teleport>',
     },
@@ -203,6 +202,33 @@ export const template: XSnippetDefinition = {
         "\t$0",
         "</$1>",
       ],
+    },
+    vTransition: {
+      name: "Vue Transition",
+      body: "<Transition $1>\n\t$0\n</Transition>",
+    },
+    "vTransition:name": {
+      name: "Vue Transition with name",
+      body: '<Transition name="$1" $2>\n\t$0\n</Transition>',
+      alt: ["nTransition"],
+    },
+    "vTransition:type": {
+      name: "Vue Transition with type",
+      body:
+        '<Transition type="${1|transition,animation|}" $2>\n\t$0\n</Transition>',
+    },
+    "vTransition:appear": {
+      name: "Vue Transition with appear",
+      body: "<Transition appear $1>\n\t$0\n</Transition>",
+    },
+    vTransitionGroup: {
+      name: "Vue TransitionGroup",
+      body:
+        '<TransitionGroup name="$1" as="${2|ul,div,section|}" $3>\n\t$0\n</TransitionGroup>',
+    },
+    vSuspense: {
+      name: "Vue Suspense",
+      body: "<Suspense>\n\t$0\n</Suspense>",
     },
   },
 };


### PR DESCRIPTION
- Add Vue Router template snippets
- Add Transition elements and Suspense snippets
- Add Vue template class and style snippets
- Update lang meta for Nuxt template syntax higlighting
- Change prefix for $computed
- Chase prefix casing for PascalCase components whose full name is part of the prefix (i.e vTransition)